### PR TITLE
Implement DaisyUI dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ After the steps above, you’ll have a working version like the demo page. Howev
   - Update title and meta description tags for every public page. We include generic ones using your site name (`src/config.ts`), but the more specific these are the better.
   - This done automatically for blog posts from `posts.ts` metadata
 - Style
-  - Theme: Update the theme to match your brand, or use one of the built in themes from DaisyUI (see `app.css`). DaisyUI can automatically use a dark mode theme on systems with dark mode enabled (disabled by default) -- to enable if remove `themes: false;` and specify a dark mode theme. Docs: https://daisyui.com/docs/themes/
+  - Theme: Update the theme to match your brand, or use one of the built in themes from DaisyUI (see `app.css`). DaisyUI automatically uses its dark theme when the system prefers dark mode. Docs: https://daisyui.com/docs/themes/
   - Update the marketing page layout `src/routes/(marketing)/+layout.svelte`: customize design, delete unwanted pages from header and footer
   - Style: make it your own look and feel.
   - Update the favicon in the `/static/` directory

--- a/src/app.css
+++ b/src/app.css
@@ -2,8 +2,10 @@
 
 @plugin '@tailwindcss/typography';
 @plugin "daisyui" {
-  /* Disable all other themes which forces the default theme created below. You can add a dark mode theme using daisyui if you like, and it will automatically use it when the user's system is in dark mode. Docs: https://daisyui.com/docs/themes/ */
-  themes: false;
+  /* Use our custom theme by default and DaisyUI's dark theme when the system prefers dark mode. */
+  themes:
+    [ "saasstartertheme --default",
+    "dark --prefersdark"];
 }
 
 @plugin "daisyui/theme" {


### PR DESCRIPTION
## Summary
- enable DaisyUI's default dark theme when the OS prefers dark mode
- document dark theme usage in README

## Testing
- `bash checks.sh` *(fails: Module '"$env/static/private"' has no exported member 'PRIVATE_STRIPE_API_KEY')*

------
https://chatgpt.com/codex/tasks/task_e_68422cfc32b0832995d96f422f6ee343